### PR TITLE
Update spin lock, no longer need nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ codecov = { repository = "PyO3/pyo3", branch = "master", service = "github" }
 
 [dependencies]
 libc = "0.2.43"
-spin = "0.4.9"
+spin = "0.5.0"
 num-traits = "0.2.6"
 pyo3cls = { path = "pyo3cls", version = "=0.5.3" }
 mashup = "0.1.9"

--- a/build.rs
+++ b/build.rs
@@ -11,12 +11,12 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
-use version_check::{is_min_date, is_min_version, supports_features};
+use version_check::{is_min_date, is_min_version};
 
 // Specifies the minimum nightly version needed to compile pyo3.
 // This requirement is due to https://github.com/rust-lang/rust/issues/55380
 const MIN_DATE: &'static str = "2018-11-02";
-const MIN_VERSION: &'static str = "1.32.0-nightly";
+const MIN_VERSION: &'static str = "1.32.0";
 
 #[derive(Debug)]
 struct PythonVersion {
@@ -510,7 +510,6 @@ fn version_from_env() -> Option<PythonVersion> {
 }
 
 fn check_rustc_version() {
-    let ok_channel = supports_features();
     let ok_version = is_min_version(MIN_VERSION);
     let ok_date = is_min_date(MIN_DATE);
 
@@ -521,14 +520,8 @@ fn check_rustc_version() {
         );
     };
 
-    match (ok_channel, ok_version, ok_date) {
-        (Some(ok_channel), Some((ok_version, version)), Some((ok_date, date))) => {
-            if !ok_channel {
-                eprintln!("Error: pyo3 requires a nightly or dev version of Rust.");
-                print_version_err(&*version, &*date);
-                panic!("Aborting compilation due to incompatible compiler.")
-            }
-
+    match (ok_version, ok_date) {
+        (Some((ok_version, version)), Some((ok_date, date))) => {
             if !ok_version || !ok_date {
                 eprintln!("Error: pyo3 requires a more recent version of rustc.");
                 eprintln!("Use `rustup update` or your preferred method to update Rust");

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -150,7 +150,7 @@ fn function_wrapper_ident(name: &syn::Ident) -> syn::Ident {
     syn::Ident::new(
         &format!(
             "__pyo3_get_function_{}",
-            name.to_string().trim_left_matches("r#")
+            name.to_string().trim_start_matches("r#")
         ),
         Span::call_site(),
     )

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -149,7 +149,7 @@ pub fn pyfunction(
 
     // Workaround for https://github.com/dtolnay/syn/issues/478
     let python_name = syn::Ident::new(
-        &ast.ident.to_string().trim_left_matches("r#"),
+        &ast.ident.to_string().trim_start_matches("r#"),
         Span::call_site(),
     );
     let expanded = module::add_fn_to_module(&mut ast, &python_name, Vec::new());


### PR DESCRIPTION
By updating the spin version nightly is no longer required to build this
crate (or ratty, so that means ratty will no longer need nightly rust -- except for the specialization and const functions in the proc macros).

Also fixed deprecated warnings